### PR TITLE
Remove Try wrapper.

### DIFF
--- a/KSPromise/Future.swift
+++ b/KSPromise/Future.swift
@@ -45,8 +45,8 @@ open class Future<T> {
         if isCompleted {
             if let v = value {
                 switch(v) {
-                case .success(let wrapper):
-                    callback(wrapper.value)
+                case .success(let value):
+                    callback(value)
                 default:
                     break;
                 }
@@ -121,9 +121,9 @@ open class Future<T> {
         _isCompleted = true
         _value = value
         switch (value) {
-        case .success(let wrapper):
+        case .success(let value):
             for callback in successCallbacks {
-                callback(wrapper.value)
+                callback(value)
             }
         case .failure(let error):
             for callback in failureCallbacks {
@@ -140,8 +140,8 @@ open class Future<T> {
 
     fileprivate func buildFlatMapFuture<U>(_ v: Try<T>, transform: (T) -> Future<U>) -> Future<U> {
         switch v {
-        case .success(let wrapper):
-            return transform(wrapper.value)
+        case .success(let value):
+            return transform(value)
         case .failure(let error):
             let newFuture = Future<U>()
             newFuture.complete(Try(error))

--- a/KSPromise/Try.swift
+++ b/KSPromise/Try.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 public enum Try<T> {
-    case success(TryValueWrapper<T>)
+    case success(T)
     case failure(NSError)
 
     public init(_ value: T) {
-        self = .success(TryValueWrapper(value))
+        self = .success(value)
     }
 
     public init(_ error: NSError) {
@@ -14,8 +14,8 @@ public enum Try<T> {
 
     public func map<U>(_ f: (T) -> U) -> Try<U> {
         switch self {
-        case .success(let wrapper):
-            return .success(TryValueWrapper(f(wrapper.value)))
+        case .success(let value):
+            return .success(f(value))
         case .failure(let error):
             return .failure(error)
         }
@@ -23,15 +23,10 @@ public enum Try<T> {
 
     public func flatMap<U>(_ f:(T) -> Try<U>) -> Try<U> {
         switch self {
-        case .success(let wrapper):
-            return f(wrapper.value)
+        case .success(let value):
+            return f(value)
         case .failure(let error):
             return .failure(error)
         }
     }
-}
-
-open class TryValueWrapper<T> {
-    open let value: T
-    public init(_ value: T) { self.value = value }
 }

--- a/KSPromise_Tests/Future_mapTry_Tests.swift
+++ b/KSPromise_Tests/Future_mapTry_Tests.swift
@@ -10,8 +10,8 @@ class Future_mapTry_Tests: XCTestCase {
 
         let mappedFuture = promise.future.mapTry() { (v) -> Try<String> in
             switch (v) {
-            case .success(let wrapper):
-                return Try<String>(wrapper.value + "B")
+            case .success(let value):
+                return Try<String>(value + "B")
             default:
                 return v
             }
@@ -30,8 +30,8 @@ class Future_mapTry_Tests: XCTestCase {
 
         let mappedFuture = promise.future.mapTry() { (v) -> Try<String> in
             switch (v) {
-            case .success(let wrapper):
-                return Try<String>(wrapper.value + "B")
+            case .success(let value):
+                return Try<String>(value + "B")
             default:
                 return v
             }
@@ -52,8 +52,8 @@ class Future_mapTry_Tests: XCTestCase {
 
         let mappedFuture = promise.future.mapTry() { (v) -> Try<String> in
             switch (v) {
-            case .success(let wrapper):
-                let myError = NSError(domain: "Error After: " + wrapper.value, code: 123, userInfo: nil)
+            case .success(let value):
+                let myError = NSError(domain: "Error After: " + value, code: 123, userInfo: nil)
                 return Try<String>(myError)
             default:
                 return v

--- a/KSPromise_Tests/Future_onComplete_Tests.swift
+++ b/KSPromise_Tests/Future_onComplete_Tests.swift
@@ -12,8 +12,8 @@ class Future_onComplete_Tests: XCTestCase {
         promise.future.onComplete() { (v) in
             done = true
             switch (v) {
-            case .success(let wrapper):
-                XCTAssertEqual("A", wrapper.value, "value passed to success is incorrect")
+            case .success(let value):
+                XCTAssertEqual("A", value, "value passed to success is incorrect")
             default:
                 XCTFail("should not have failed")
             }
@@ -28,8 +28,8 @@ class Future_onComplete_Tests: XCTestCase {
         promise.future.onComplete() { (v) in
             done = true
             switch (v) {
-            case .success(let wrapper):
-                XCTAssertEqual("A", wrapper.value, "value passed to success is incorrect")
+            case .success(let value):
+                XCTAssertEqual("A", value, "value passed to success is incorrect")
             default:
                 XCTFail("should not have failed")
             }

--- a/KSPromise_Tests/Promise_Tests.swift
+++ b/KSPromise_Tests/Promise_Tests.swift
@@ -10,8 +10,8 @@ class Promise_Tests: XCTestCase {
 
         if let value = promise.future.value {
             switch value {
-            case .success(let wrapper):
-                XCTAssertEqual(wrapper.value, "A", "value should not have updated")
+            case .success(let value):
+                XCTAssertEqual(value, "A", "value should not have updated")
             case .failure:
                 XCTFail("should not have failed")
             }

--- a/KSPromise_Tests/Try_flatMap_Tests.swift
+++ b/KSPromise_Tests/Try_flatMap_Tests.swift
@@ -11,8 +11,8 @@ class Try_flatMap_Tests: XCTestCase {
         }
 
         switch(result) {
-        case .success(let wrapper):
-            XCTAssertEqual(wrapper.value, "AB", "value was not mapped")
+        case .success(let value):
+            XCTAssertEqual(value, "AB", "value was not mapped")
         case .failure:
             XCTFail("Should not error")
         }

--- a/KSPromise_Tests/Try_map_Tests.swift
+++ b/KSPromise_Tests/Try_map_Tests.swift
@@ -11,8 +11,8 @@ class Try_map_Tests: XCTestCase {
         }
 
         switch(result) {
-        case .success(let wrapper):
-            XCTAssertEqual(wrapper.value, "AB", "value was not mapped")
+        case .success(let value):
+            XCTAssertEqual(value, "AB", "value was not mapped")
         case .failure:
             XCTFail("Should not error")
         }


### PR DESCRIPTION
This type was a workaround for earlier swift versions and
is no longer necessary.